### PR TITLE
Update to JDA V4 and add new get methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,52 @@ RequestHandler handler = new RequestHandler();
 handler.postGuilds(jda, api);
 ```
 
+### Getting botinfo
+JavaBotBlockAPI allows you to receive informations.
+There aren't that many methods to use due to the nature of the sites returning different informations.
+
+#### Receive full JSON
+You can use the `getAll(...)` method to receive the full JSON of the BotBlock API.
+```java
+// We need to get an instance of RequestHandler to use the methods.
+RequestHandler handler = new RequestHandler();
+
+// Like with all other methods can you use JDA, ShardManager or ID.
+JSONObject json = handler.getAll(jda);
+```
+
+#### Receive Owners
+You can use `getOwners(...)` to receive a List of all owners of the bot.
+```java
+// We need to get an instance of RequestHandler to use the methods.
+RequestHandler handler = new RequestHandler();
+
+// Like with all other methods can you use JDA, ShardManager or ID.
+List<String> owners = handler.getOwners(jda);
+```
+
+#### Receive all botlists.
+If you only want the Botlists and their information, use `getBotlists(...)`.
+It is returned as a JSONObject.
+```java
+// We need to get an instance of RequestHandler to use the methods.
+RequestHandler handler = new RequestHandler();
+
+// Like with all other methods can you use JDA, ShardManager or ID.
+JSONObject json = handler.getBotlists(jda);
+```
+
+#### Receive certain Botlist info
+You can use `getBotlist(..., String)` to get the information of a specific botlist.
+The information you receive is given as JSONArray and depends on what the botlist returns.
+```java
+// We need to get an instance of RequestHandler to use the methods.
+RequestHandler handler = new RequestHandler();
+
+// Like with all other methods can you use JDA, ShardManager or ID.
+JSONArray array = handler.getBotlist(jda, "lbots.org");
+```
+
 ### Exceptions
 When you post the guild counts you could encounter certain Exceptions.  
 You can receive the following exceptions:

--- a/README.md
+++ b/README.md
@@ -53,36 +53,36 @@ This will also work with ShardManager.
 You can post you guild counts to the different Botlists using the BotBlock API.
 
 ### Creating an instance of BotBlockAPI
-For posting your guild counts towards the BotBlock API you first need to create an instance of the BotBlockAPI class.
+For posting your guild counts towards the BotBlock API you first need to create an instance of the BotBlockAPI class.  
 To do this it's recommended to use `BotBlockAPI.Builder()`.
 
-Here is an example of how it could look like.
+Here is an example of how it could look like.  
 ```java
 BotBlockAPI api = new BotBlockAPI.Builder()
     .addAuthToken("lbots.org", "MySecretToken123")
     .addAuthToken("botlist.space", "MySecretToken456")
     .build();
-```
+```  
 Remember to use `.build();` at the end to create the class.
 
 ### Auto Posting
-JavaBotBlockAPI allows you to post the guild counts automatically every X minutes.
+JavaBotBlockAPI allows you to post the guild counts automatically every X minutes.  
 To do this, you first need to get an instance of the RequestHandler and then call `.startAutoPosting(...)`.
 
-Here is an example:
+Here is an example:  
 ```java
 RequestHandler handler = new RequestHandler();
 
 // api is the instance of the BotBlockAPI
 handler.startAutoPosting(jda, api);
-```
+```  
 The delay in which you post the guild counts is set through the `.setUpdateInterval(int)` method in the BotBlockAPI.Builder().
 
 ### Cancel auto posting
 To cancel the auto posting just call `.stopAutoPosting();` in the RequestHandler and it should cancel the scheduler.
 
 ### Manually posting
-There are methods that allow you to post the guild counts manually.
+There are methods that allow you to post the guild counts manually.  
 To Post your guild counts, just call the `.postGuilds(..., ...)` method in the RequestHandler.
 
 ```java
@@ -98,7 +98,7 @@ Since version 2.0.0 of JavaBotBlockAPI can you get certain informations of a bot
 ### All available Botlists
 You can call `.getBotlists()` to receive a JSONObject with all available Botlists in the BotBlockAPI.
 
-The returned JSONObject could look like this:
+The returned JSONObject could look like this:  
 ```json
 {
     "botlist.space": {
@@ -123,8 +123,8 @@ The returned JSONObject could look like this:
 ```
 
 ### Single Botlist
-Calling `.getBotlist(String)` returns a specific Botlist as JSONObject.
-For example does `.getBotlist("lbots.org")` return the following JSONObject:
+Calling `.getBotlist(String)` returns a specific Botlist as JSONObject.  
+For example does `.getBotlist("lbots.org")` return the following JSONObject:  
 ```json
 {
     "api_docs": "https://lbots.org/api/docs",
@@ -140,7 +140,7 @@ For example does `.getBotlist("lbots.org")` return the following JSONObject:
 ### Complete Botinfo
 Calling `.getAll(...)` returns a JSONObject from all the botlists and with some general information.
 
-The JSONObject can look like this:
+The JSONObject can look like this:  
 ```json
 {
     "id": "123456789012345678",
@@ -162,15 +162,14 @@ The JSONObject can look like this:
         ]
     }
 }
-```
-
-`<data>` is the JSON that is returned by the provided Botlist meaning it's different for each site.
+```  
+`<data>` is the JSON that is returned by the provided Botlist meaning it's different for each site.  
 `name`, `owners`, `server_count` and `invite` is based on the most common appearances of the data.
 
 ### Botinfo from all Botlists
 You can call `.getBotInfos(...)` to only receive the bot info from all the Botlists.
 
-The returned JSONObject can look like this:
+The returned JSONObject can look like this:  
 ```json
 {
     "botlist.space": [
@@ -182,15 +181,15 @@ The returned JSONObject can look like this:
         404
     ]
 }
-```
+```  
 `<data>` is the JSON that is returned by the provided Botlist meaning it's different for each site.
 
 ### Botinfo of a single site
-With `.getBotInfo(..., String)` can you receive the info of a specific site.
+With `.getBotInfo(..., String)` can you receive the info of a specific site.  
 The returned data depends on the selected site and can be different for each one.
 
 ### Owners
-You can call `.getOwners(...)` to get the owners of a Bot from all the Botlists.
+You can call `.getOwners(...)` to get the owners of a Bot from all the Botlists.  
 The info is returned as JSONArray and is based on how often the info is provided by the botlists.
 
 ## Exceptions

--- a/README.md
+++ b/README.md
@@ -153,17 +153,17 @@ The JSONObject can look like this:
     "invite": "https://discordapp.com/oauth2/authorize?client_id=123456789012345678&scope=bot",
     "list_data": {
         "botlist.space": [
-            <data>,
+            {"data"},
             200
         ],
         "lbots.org": [
-            <data>,
+            {"data"},
             404
         ]
     }
 }
 ```  
-`<data>` is the JSON that is returned by the provided Botlist meaning it's different for each site.  
+`{"data"}` is the JSON that is returned by the provided Botlist meaning it's different for each site.  
 `name`, `owners`, `server_count` and `invite` is based on the most common appearances of the data.
 
 ### Botinfo from all Botlists
@@ -173,16 +173,16 @@ The returned JSONObject can look like this:
 ```json
 {
     "botlist.space": [
-        <data>,
+        {"data"},
         200
     ],
     "lbots.org": [
-        <data>,
+        {"data"},
         404
     ]
 }
 ```  
-`<data>` is the JSON that is returned by the provided Botlist meaning it's different for each site.
+`{"data"}` is the JSON that is returned by the provided Botlist meaning it's different for each site.
 
 ### Botinfo of a single site
 With `.getBotInfo(..., String)` can you receive the info of a specific site.  

--- a/README.md
+++ b/README.md
@@ -9,17 +9,16 @@
 [BadgeDownload]: https://api.bintray.com/packages/andre601/maven/JavaBotBlockAPI/images/download.svg
 [Download]: https://bintray.com/andre601/maven/JavaBotBlockAPI/_latestVersion
 
-# JavaBotBlockAPI
 JavaBotBlockAPI is a continued and updated Java Wrapper for [BotBlock], a website that makes it possible to update guild counts on multiple lists with one API.  
 This wrapper is a fork of [BotBlock4J] and was updated and improved to make it as userfriendly as possible.
 
-## Installation
+# Installation
 [![BadgeDownload]][Download]
 
 You can install JavaBotBlockAPI through the following methods.  
 Make sure to replace `{version}` with the above shown version.
 
-### Gradle
+## Gradle
 Put this code into your `build.gradle`:  
 ```gradle
 repositories{
@@ -31,7 +30,7 @@ dependencies{
 }
 ```
 
-### Maven
+## Maven
 For maven use this code snipped:  
 ```xml
 <dependencies>
@@ -43,108 +42,158 @@ For maven use this code snipped:
 </dependencies>
 ```
 
-## Usage
+# Usage
 To use the Wrapper you have to follow these steps.
 
-### Notes
+## Notes
 In the below examples do I use a JDA instance called `jda`.  
 This will also work with ShardManager.
 
-### Creating a BotBlockAPI instance
-You first need to create an instance of the BotBlockAPI class.  
-This class is the center of everything, including on what sites you want to post your guild counts.
+## POST methods
+You can post you guild counts to the different Botlists using the BotBlock API.
 
-You can use the internal Builder class of BotBlockAPI to create an instance. It would look something like this:  
+### Creating an instance of BotBlockAPI
+For posting your guild counts towards the BotBlock API you first need to create an instance of the BotBlockAPI class.
+To do this it's recommended to use `BotBlockAPI.Builder()`.
+
+Here is an example of how it could look like.
 ```java
-// Creating an instance of BotBlockAPI using BotBlockAPI.Builder
 BotBlockAPI api = new BotBlockAPI.Builder()
-    .addAuthToken("lbots.org", "MySecretToken123") // Adds a site with the corresponding API token.
-    .addAuthToken("botlist.space", "MySecretToken456") // The builder allows chaining of the methods.
+    .addAuthToken("lbots.org", "MySecretToken123")
+    .addAuthToken("botlist.space", "MySecretToken456")
     .build();
 ```
+Remember to use `.build();` at the end to create the class.
 
-#### Notes
-There are a lot of other methods that you can use. Head over to the [Wiki] for more information.
+### Auto Posting
+JavaBotBlockAPI allows you to post the guild counts automatically every X minutes.
+To do this, you first need to get an instance of the RequestHandler and then call `.startAutoPosting(...)`.
 
-### Posting
-You can post the guilds either automatically or manually depending on your own preferences.
-
-#### Auto-posting
-JavaBotBlockAPI comes with an inbuilt scheduler to post your guilds automatically.
-To use it simply use the `startAutoPosting` method and provide either a JDA instance, ShardManager instance or the bot id and guild count.
-
-**Example**:  
+Here is an example:
 ```java
-// We need to get an instance of RequestHandler to use the methods.
 RequestHandler handler = new RequestHandler();
 
-// jda is a JDA instance and api a BotBlockAPI instance.
+// api is the instance of the BotBlockAPI
 handler.startAutoPosting(jda, api);
 ```
+The delay in which you post the guild counts is set through the `.setUpdateInterval(int)` method in the BotBlockAPI.Builder().
 
-But what if you want to stop it?  
-For that just call the `stopAutoPosting` method:  
-```
-handler.stopAutoPosting();
-```
+### Cancel auto posting
+To cancel the auto posting just call `.stopAutoPosting();` in the RequestHandler and it should cancel the scheduler.
 
-#### Manual posting
-If you want to post the guild counts manually you can use the `postGuilds` method.  
+### Manually posting
+There are methods that allow you to post the guild counts manually.
+To Post your guild counts, just call the `.postGuilds(..., ...)` method in the RequestHandler.
+
 ```java
-// We need to get an instance of RequestHandler to use the methods.
 RequestHandler handler = new RequestHandler();
 
-// jda is a JDA instance and api a BotBlockAPI instance.
+// api is the instance of the BotBlockAPI
 handler.postGuilds(jda, api);
 ```
 
-### Getting botinfo
-JavaBotBlockAPI allows you to receive different information of a certain bot.  
-What the sites returns can be completely different. There are only methods to receive general informations.  
+## GET methods
+Since version 2.0.0 of JavaBotBlockAPI can you get certain informations of a bot or the available Botlists on the BotBlock API.
 
-#### Receive full JSON
-You can use the `getAll(...)` method to receive the full JSON of the BotBlock API.  
-```java
-// We need to get an instance of RequestHandler to use the methods.
-RequestHandler handler = new RequestHandler();
+### All available Botlists
+You can call `.getBotlists()` to receive a JSONObject with all available Botlists in the BotBlockAPI.
 
-// Like with all other methods can you use JDA, ShardManager or ID.
-JSONObject json = handler.getAll(jda);
+The returned JSONObject could look like this:
+```json
+{
+    "botlist.space": {
+        "api_docs": "https://docs.botlist.space",
+        "api_post": "https://api.botlist.space/v1/bots/:id",
+        "api_field": "server_count",
+        "api_shard_id": null,
+        "api_shard_count": null,
+        "api_shards": "shards",
+        "api_get": "https://api.botlist.space/v1/bots/:id"
+    },
+    "lbots.org": {
+        "api_docs": "https://lbots.org/api/docs",
+        "api_post": "https://lbots.org/api/v1/bots/:id/stats",
+        "api_field": "guild_count",
+        "api_shard_id": "shard_id",
+        "api_shard_count": "shard_count",
+        "api_shards": null,
+        "api_get": null
+    }
+}
 ```
 
-#### Receive Owners
-You can use `getOwners(...)` to receive a List of all owners of the bot.  
-```java
-// We need to get an instance of RequestHandler to use the methods.
-RequestHandler handler = new RequestHandler();
-
-// Like with all other methods can you use JDA, ShardManager or ID.
-List<String> owners = handler.getOwners(jda);
+### Single Botlist
+Calling `.getBotlist(String)` returns a specific Botlist as JSONObject.
+For example does `.getBotlist("lbots.org")` return the following JSONObject:
+```json
+{
+    "api_docs": "https://lbots.org/api/docs",
+    "api_post": "https://lbots.org/api/v1/bots/:id/stats",
+    "api_field": "guild_count",
+    "api_shard_id": "shard_id",
+    "api_shard_count": "shard_count",
+    "api_shards": null,
+    "api_get": null
+}
 ```
 
-#### Receive all botlists.
-If you only want the Botlists and their information, use `getBotlists(...)`.  
-It is returned as a JSONObject.  
-```java
-// We need to get an instance of RequestHandler to use the methods.
-RequestHandler handler = new RequestHandler();
+### Complete Botinfo
+Calling `.getAll(...)` returns a JSONObject from all the botlists and with some general information.
 
-// Like with all other methods can you use JDA, ShardManager or ID.
-JSONObject json = handler.getBotlists(jda);
+The JSONObject can look like this:
+```json
+{
+    "id": "123456789012345678",
+    "name": "MyBot",
+    "discriminator": "1234",
+    "owners": [
+        "234567890123456789"
+    ],
+    "server_count": 100,
+    "invite": "https://discordapp.com/oauth2/authorize?client_id=123456789012345678&scope=bot",
+    "list_data": {
+        "botlist.space": [
+            <data>,
+            200
+        ],
+        "lbots.org": [
+            <data>,
+            404
+        ]
+    }
+}
 ```
 
-#### Receive certain Botlist info
-You can use `getBotlist(..., String)` to get the information of a specific botlist.  
-The information you receive is given as JSONArray and depends on what the botlist returns.  
-```java
-// We need to get an instance of RequestHandler to use the methods.
-RequestHandler handler = new RequestHandler();
+`<data>` is the JSON that is returned by the provided Botlist meaning it's different for each site.
+`name`, `owners`, `server_count` and `invite` is based on the most common appearances of the data.
 
-// Like with all other methods can you use JDA, ShardManager or ID.
-JSONArray array = handler.getBotlist(jda, "lbots.org");
+### Botinfo from all Botlists
+You can call `.getBotInfos(...)` to only receive the bot info from all the Botlists.
+
+The returned JSONObject can look like this:
+```json
+{
+    "botlist.space": [
+        <data>,
+        200
+    ],
+    "lbots.org": [
+        <data>,
+        404
+    ]
+}
 ```
+`<data>` is the JSON that is returned by the provided Botlist meaning it's different for each site.
 
-### Exceptions
+### Botinfo of a single site
+With `.getBotInfo(..., String)` can you receive the info of a specific site.
+The returned data depends on the selected site and can be different for each one.
+
+### Owners
+You can call `.getOwners(...)` to get the owners of a Bot from all the Botlists.
+The info is returned as JSONArray and is based on how often the info is provided by the botlists.
+
+## Exceptions
 When you post the guild counts you could encounter certain Exceptions.  
 You can receive the following exceptions:
 - `IOException`  
@@ -155,7 +204,7 @@ This shouldn't be the case with auto-posting since it has a minimum delay of 1 m
 - `NullPointerException`  
 Thrown when BotBlock.org sends an empty response, meaning something got messed up on their side.
 
-## Links
+# Links
 Here are some useful links:
 - [BotBlock.org][BotBlock] Site for which this wrapper was made.
   - [API] API documentation.

--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ handler.postGuilds(jda, api);
 ```
 
 ### Getting botinfo
-JavaBotBlockAPI allows you to receive informations.
-There aren't that many methods to use due to the nature of the sites returning different informations.
+JavaBotBlockAPI allows you to receive different information of a certain bot.  
+What the sites returns can be completely different. There are only methods to receive general informations.  
 
 #### Receive full JSON
-You can use the `getAll(...)` method to receive the full JSON of the BotBlock API.
+You can use the `getAll(...)` method to receive the full JSON of the BotBlock API.  
 ```java
 // We need to get an instance of RequestHandler to use the methods.
 RequestHandler handler = new RequestHandler();
@@ -113,7 +113,7 @@ JSONObject json = handler.getAll(jda);
 ```
 
 #### Receive Owners
-You can use `getOwners(...)` to receive a List of all owners of the bot.
+You can use `getOwners(...)` to receive a List of all owners of the bot.  
 ```java
 // We need to get an instance of RequestHandler to use the methods.
 RequestHandler handler = new RequestHandler();
@@ -123,8 +123,8 @@ List<String> owners = handler.getOwners(jda);
 ```
 
 #### Receive all botlists.
-If you only want the Botlists and their information, use `getBotlists(...)`.
-It is returned as a JSONObject.
+If you only want the Botlists and their information, use `getBotlists(...)`.  
+It is returned as a JSONObject.  
 ```java
 // We need to get an instance of RequestHandler to use the methods.
 RequestHandler handler = new RequestHandler();
@@ -134,8 +134,8 @@ JSONObject json = handler.getBotlists(jda);
 ```
 
 #### Receive certain Botlist info
-You can use `getBotlist(..., String)` to get the information of a specific botlist.
-The information you receive is given as JSONArray and depends on what the botlist returns.
+You can use `getBotlist(..., String)` to get the information of a specific botlist.  
+The information you receive is given as JSONArray and depends on what the botlist returns.  
 ```java
 // We need to get an instance of RequestHandler to use the methods.
 RequestHandler handler = new RequestHandler();

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies{
     implementation group: 'org.json', name: 'json', version: '20180813'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
     implementation group: 'org.jetbrains', name: 'annotations', version: '16.0.2'
-    api(group: 'net.dv8tion', name: 'JDA', version: '4.BETA.0_11'){
+    api(group: 'net.dv8tion', name: 'JDA', version: '4.BETA.0_23'){
         exclude(module: 'opus-java')
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies{
     implementation group: 'org.json', name: 'json', version: '20180813'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
     implementation group: 'org.jetbrains', name: 'annotations', version: '16.0.2'
-    api(group: 'net.dv8tion', name: 'JDA', version: '3.8.3_463'){
+    api(group: 'net.dv8tion', name: 'JDA', version: '4.BETA.0_11'){
         exclude(module: 'opus-java')
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ repositories{
 dependencies{
     implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.11.0'
     implementation group: 'org.json', name: 'json', version: '20180813'
-    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
     implementation group: 'org.jetbrains', name: 'annotations', version: '16.0.2'
     api(group: 'net.dv8tion', name: 'JDA', version: '4.BETA.0_23'){
         exclude(module: 'opus-java')

--- a/build.gradle
+++ b/build.gradle
@@ -21,20 +21,20 @@ repositories{
 }
 
 dependencies{
-    implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.11.0'
-    implementation group: 'org.json', name: 'json', version: '20180813'
-    implementation group: 'org.jetbrains', name: 'annotations', version: '16.0.2'
+    api group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.11.0'
+    api group: 'org.json', name: 'json', version: '20180813'
+    api group: 'org.jetbrains', name: 'annotations', version: '16.0.2'
     api(group: 'net.dv8tion', name: 'JDA', version: '4.BETA.0_23'){
         exclude(module: 'opus-java')
     }
 }
 
-task sourcesJar(type: Jar, dependsOn: classes) {
+task sourcesJar(type: Jar, dependsOn: classes){
     classifier = 'sources'
     from sourceSets.main.allSource
 }
 
-task javadocJar(type: Jar, dependsOn: javadoc) {
+task javadocJar(type: Jar, dependsOn: javadoc){
     classifier = 'javadoc'
     from javadoc.destinationDir
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins{
 }
 
 group = 'com.andre601'
-version = '1.0.5'
+version = '1.1.0'
 
 sourceCompatibility = 1.8
 

--- a/src/main/java/com/andre601/javabotblockapi/BotBlockAPI.java
+++ b/src/main/java/com/andre601/javabotblockapi/BotBlockAPI.java
@@ -18,14 +18,13 @@
  */
 package com.andre601.javabotblockapi;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Class for handling the sites to post to and the delay for the auto-post option in
+ * Class for handling the sites to post to and the delay for the auto-post option in the
  * {@link com.andre601.javabotblockapi.RequestHandler RequestHandler}.
  */
 public class BotBlockAPI{
@@ -48,7 +47,7 @@ public class BotBlockAPI{
     }
 
     /**
-     * Creates an instance of BotBlockAPI with the provided api tokens (as Map) and update interval.
+     * Constructor to set the Map with the sites and tokens and also the update delay..
      *
      * @param authTokens
      *        A Map of sites and their tokens. May not be null.
@@ -57,6 +56,9 @@ public class BotBlockAPI{
      *        The update interval to set.
      */
     public BotBlockAPI(@NotNull Map<String, String> authTokens, int updateInterval){
+        if(updateInterval < 2)
+            throw new IllegalArgumentException("Update interval may not be less than 2.");
+
         this.authTokens = authTokens;
         this.updateInterval = updateInterval;
     }
@@ -98,8 +100,8 @@ public class BotBlockAPI{
          * @return The Builder after the site and token were set. Useful for chaining.
          */
         public Builder addAuthToken(@NotNull String site, @NotNull String token){
-            if(ObjectUtils.isEmpty(site) || ObjectUtils.isEmpty(token))
-                throw new NullPointerException("Empty site and/or token is not allowed!");
+            Check.notEmpty(site, "Site may not be empty.");
+            Check.notEmpty(token, "Token may not be empty.");
 
             authTokens.put(site, token);
 
@@ -119,8 +121,7 @@ public class BotBlockAPI{
          * @return The Builder after the Map was set. Useful for chaining.
          */
         public Builder setAuthTokens(@NotNull Map<String, String> authTokens){
-            if(ObjectUtils.isEmpty(authTokens))
-                throw new NullPointerException("Empty Map for authTokens is not allowed!");
+            Check.notEmpty(authTokens, "AuthTokens may not be null.");
 
             this.authTokens = authTokens;
 
@@ -141,7 +142,7 @@ public class BotBlockAPI{
          */
         public Builder setUpdateInteval(int updateInterval){
             if(updateInterval < 2)
-                throw new IllegalArgumentException("updateInterval can't be less than 2!");
+                throw new IllegalArgumentException("Update interval may not be less than 2.");
 
             this.updateInterval = updateInterval;
 

--- a/src/main/java/com/andre601/javabotblockapi/BotBlockAPI.java
+++ b/src/main/java/com/andre601/javabotblockapi/BotBlockAPI.java
@@ -29,14 +29,30 @@ import java.util.Map;
  * {@link com.andre601.javabotblockapi.RequestHandler RequestHandler}.
  */
 public class BotBlockAPI{
+    private static final int DEFAULT_DELAY = 30;
+
     private Map<String, String> authTokens;
     private int updateInterval;
+
+    /**
+     * Constructor to set the Map with the sites and tokens.
+     * <br>This will also set the update interval to 30 minutes.
+     *
+     * @param authTokens
+     *        A Map of sites and their tokens. May not be null.
+     *        <br>You may receive the API-token from your botlist.
+     */
+    public BotBlockAPI(@NotNull Map<String, String> authTokens){
+        this.authTokens = authTokens;
+        this.updateInterval = DEFAULT_DELAY;
+    }
 
     /**
      * Creates an instance of BotBlockAPI with the provided api tokens (as Map) and update interval.
      *
      * @param authTokens
      *        A Map of sites and their tokens. May not be null.
+     *        <br>You may receive the API-token from your botlist.
      * @param updateInterval
      *        The update interval to set.
      */
@@ -58,7 +74,7 @@ public class BotBlockAPI{
      */
     public static class Builder{
         private Map<String, String> authTokens = new HashMap<>();
-        private int updateInterval = 30;
+        private int updateInterval = DEFAULT_DELAY;
 
         /**
          * Empty constructor to get the class.
@@ -67,13 +83,14 @@ public class BotBlockAPI{
 
         /**
          * Adds the provided Site name and token to the Map.
-         * <br>If there is already an entry with the same key, it will be overwritten.
+         * <br>Entries with the same key will be overwritten.
          *
          * @param  site
          *         The name of the site. May not be null.
          *         <br>A list of supported sites can be found <a href="https://botblock.org/api/docs#count" target="_blank">here</a>.
          * @param  token
          *         The API token you get from the corresponding botlist. May not be null.
+         *         <br>You may receive the API-token from your botlist.
          *
          * @throws NullPointerException
          *         When either the site or token are empty ({@code ""}).

--- a/src/main/java/com/andre601/javabotblockapi/Check.java
+++ b/src/main/java/com/andre601/javabotblockapi/Check.java
@@ -2,20 +2,20 @@ package com.andre601.javabotblockapi;
 
 import java.util.Map;
 
-public class Check {
+class Check {
 
-    public static void notNull(Object target, String msg){
+    static void notNull(Object target, String msg){
         if(target == null)
             throw new NullPointerException(msg);
     }
 
-    public static void notEmpty(CharSequence arguments, String msg){
+    static void notEmpty(CharSequence arguments, String msg){
         notNull(arguments, msg);
         if(arguments.length() == 0)
             throw new NullPointerException(msg);
     }
 
-    public static void notEmpty(Map map, String msg){
+    static void notEmpty(Map map, String msg){
         notNull(map, msg);
         if(map.isEmpty())
             throw new NullPointerException(msg);

--- a/src/main/java/com/andre601/javabotblockapi/Check.java
+++ b/src/main/java/com/andre601/javabotblockapi/Check.java
@@ -1,0 +1,23 @@
+package com.andre601.javabotblockapi;
+
+import java.util.Map;
+
+public class Check {
+
+    public static void notNull(Object target, String msg){
+        if(target == null)
+            throw new NullPointerException(msg);
+    }
+
+    public static void notEmpty(CharSequence arguments, String msg){
+        notNull(arguments, msg);
+        if(arguments.length() == 0)
+            throw new NullPointerException(msg);
+    }
+
+    public static void notEmpty(Map map, String msg){
+        notNull(map, msg);
+        if(map.isEmpty())
+            throw new NullPointerException(msg);
+    }
+}

--- a/src/main/java/com/andre601/javabotblockapi/RequestHandler.java
+++ b/src/main/java/com/andre601/javabotblockapi/RequestHandler.java
@@ -330,6 +330,8 @@ public class RequestHandler {
      * @throws RatelimitedException
      *         When the API gets ratelimited.
      *
+     * @since v1.1.0
+     *
      * @see #getOwners(String) getOwners(String)
      */
     public List<String> getOwners(@NotNull ShardManager shardManager) throws IOException, RatelimitedException{
@@ -351,10 +353,34 @@ public class RequestHandler {
      * @throws RatelimitedException
      *         When the API gets ratelimited.
      *
+     * @since v1.1.0
+     *
      * @see #getOwners(String) getOwners(String)
      */
     public List<String> getOwners(@NotNull JDA jda) throws IOException, RatelimitedException{
         return getOwners(jda.getSelfUser().getId());
+    }
+
+    /**
+     * Gets the owners of a bot as a list.
+     * <br>This method calls {@link com.andre601.javabotblockapi.RequestHandler#getAll(String) getOwners(String)}.
+     *
+     * @param  id
+     *         The id of the bot.
+     *
+     * @return The owners as a list.
+     *
+     * @throws IOException
+     *         When the request couldn't be performed properly.
+     * @throws RatelimitedException
+     *         When the API gets ratelimited.
+     *
+     * @since v1.1.0
+     *
+     * @see #getOwners(String) getOwners(String)
+     */
+    public List<String> getOwners(Long id) throws IOException, RatelimitedException{
+        return getOwners(Long.toString(id));
     }
 
     /**
@@ -369,6 +395,8 @@ public class RequestHandler {
      *         When the post request couldn't be performed properly.
      * @throws RatelimitedException
      *         When the Bot (IP or ID) got ratelimited.
+     *
+     * @since v1.1.0
      */
     public List<String> getOwners(@NotNull String id) throws IOException, RatelimitedException{
         JSONObject json = getAll(id);
@@ -387,18 +415,18 @@ public class RequestHandler {
      * <br>This method calls {@link com.andre601.javabotblockapi.RequestHandler#getBotlists(String) getBotlists(String)}.
      *
      * <p>The JSONObject will look something like this:
-     * <br><pre>{@code
+     * <br><pre><code>
      * {
      *   "somebotlist.com": [
-     *     <botlist data>,
+     *    {@literal <botlist data>},
      *     200
      *   ],
      *   "otherlist.org": [
-     *     <botlist data>,
+     *    {@literal <botlist data>},
      *     404
      *   ]
      * }
-     * }</pre>
+     * </code></pre>
      *
      * @param  shardManager
      *         The {@link net.dv8tion.jda.api.sharding.ShardManager ShardManager instance} that should be used.
@@ -410,30 +438,31 @@ public class RequestHandler {
      * @throws RatelimitedException
      *         When the API gets ratelimited.
      *
+     * @since v1.1.0
+     *
      * @see #getBotlists(String) getBotlists(String)
      */
     public JSONObject getBotlists(@NotNull ShardManager shardManager) throws IOException, RatelimitedException{
         return getBotlists(shardManager.getShardById(0).getSelfUser().getId());
     }
 
-
     /**
      * Gets all the available Botlists as JSONObject.
      * <br>This method calls {@link com.andre601.javabotblockapi.RequestHandler#getBotlists(String) getBotlists(String)}.
      *
      * <p>The JSONObject will look something like this:
-     * <br><pre>{@code
+     * <br><pre><code>
      * {
      *   "somebotlist.com": [
-     *     <botlist data>,
+     *    {@literal <botlist data>},
      *     200
      *   ],
      *   "otherlist.org": [
-     *     <botlist data>,
+     *    {@literal <botlist data>},
      *     404
      *   ]
      * }
-     * }</pre>
+     * </code></pre>
      *
      * @param  jda
      *         The {@link net.dv8tion.jda.api.JDA jda instance} that should be used.
@@ -445,29 +474,66 @@ public class RequestHandler {
      * @throws RatelimitedException
      *         When the API gets ratelimited.
      *
+     * @since v1.1.0
+     *
      * @see #getBotlists(String) getBotlists(String)
      */
     public JSONObject getBotlists(@NotNull JDA jda) throws IOException, RatelimitedException{
         return getBotlists(jda.getSelfUser().getId());
     }
 
+    /**
+     * Gets all the available Botlists as JSONObject.
+     * <br>This method calls {@link com.andre601.javabotblockapi.RequestHandler#getBotlists(String) getBotlists(String)}.
+     *
+     * <p>The JSONObject will look something like this:
+     * <br><pre><code>
+     * {
+     *   "somebotlist.com": [
+     *    {@literal <botlist data>},
+     *     200
+     *   ],
+     *   "otherlist.org": [
+     *    {@literal <botlist data>},
+     *     404
+     *   ]
+     * }
+     * </code></pre>
+     *
+     * @param  id
+     *         The id of the bot.
+     *
+     * @return The Botlists as JSONObject.
+     *
+     * @throws IOException
+     *         When the request couldn't be performed properly.
+     * @throws RatelimitedException
+     *         When the API gets ratelimited.
+     *
+     * @since v1.1.0
+     *
+     * @see #getBotlists(String) getBotlists(String)
+     */
+    public JSONObject getBotlists(Long id) throws IOException, RatelimitedException{
+        return getBotlists(Long.toString(id));
+    }
 
     /**
      * Gets all the available Botlists as JSONObject.
      *
      * <p>The JSONObject will look something like this:
-     * <br><pre>{@code
+     * <br><pre><code>
      * {
      *   "somebotlist.com": [
-     *     <botlist data>,
+     *    {@literal <botlist data>},
      *     200
      *   ],
      *   "otherlist.org": [
-     *     <botlist data>,
+     *    {@literal <botlist data>},
      *     404
      *   ]
      * }
-     * }</pre>
+     * </code></pre>
      *
      * @param  id
      *         The id of the bot
@@ -478,6 +544,8 @@ public class RequestHandler {
      *         When the request couldn't be performed properly.
      * @throws RatelimitedException
      *         When the API gets ratelimited.
+     *
+     * @since v1.1.0
      */
     public JSONObject getBotlists(@NotNull String id) throws IOException, RatelimitedException{
         return getAll(id).getJSONObject("list_data");
@@ -487,12 +555,12 @@ public class RequestHandler {
      * Gets a specific botlist-information as JSONArray.
      *
      * <p>The JSONObject will look something like this:
-     * <br><pre>{@code
+     * <br><pre><code>
      * {[
-     *   <botlist data>,
+     *  {@literal <botlist data>},
      *   200
      * ]}
-     * }</pre>
+     * </code></pre>
      *
      * @param  shardManager
      *         The {@link net.dv8tion.jda.api.sharding.ShardManager ShardManager instance} that should be used.
@@ -517,12 +585,44 @@ public class RequestHandler {
      * Gets a specific botlist-information as JSONArray.
      *
      * <p>The JSONObject will look something like this:
-     * <br><pre>{@code
+     * <br><pre><code>
      * {[
-     *   <botlist data>,
+     *  {@literal <botlist data>},
      *   200
      * ]}
-     * }</pre>
+     * </code></pre>
+     *
+     * @param  id
+     *         The id of the bot.
+     * @param  site
+     *         The sites name to get information from.
+     *         <br>A list of supported sites can be found <a href="https://botblock.org/api/docs#count" target="_blank">here</a>.
+     *
+     * @return The sites information as JSONArray.
+     *
+     * @throws IOException
+     *         When the request couldn't be performed properly.
+     * @throws RatelimitedException
+     *         When the API gets ratelimited.
+     *
+     * @since v1.1.0
+     *
+     * @see #getBotlist(String, String) getBotlist(String, String)
+     */
+    public JSONArray getBotlist(Long id, @NotNull String site) throws IOException, RatelimitedException{
+        return getBotlist(Long.toString(id), site);
+    }
+
+    /**
+     * Gets a specific botlist-information as JSONArray.
+     *
+     * <p>The JSONObject will look something like this:
+     * <br><pre><code>
+     * {[
+     *  {@literal <botlist data>},
+     *   200
+     * ]}
+     * </code></pre>
      *
      * @param  jda
      *         The {@link net.dv8tion.jda.api.JDA JDA instance} that should be used.
@@ -537,6 +637,8 @@ public class RequestHandler {
      * @throws RatelimitedException
      *         When the API gets ratelimited.
      *
+     * @since v1.1.0
+     *
      * @see #getBotlist(String, String) getBotlist(String, String)
      */
     public JSONArray getBotlist(@NotNull JDA jda, String site) throws IOException, RatelimitedException{
@@ -547,12 +649,12 @@ public class RequestHandler {
      * Gets a specific botlist-information as JSONArray.
      *
      * <p>The JSONObject will look something like this:
-     * <br><pre>{@code
+     * <br><pre><code>
      * {[
-     *   <botlist data>,
+     *  {@literal <botlist data>},
      *   200
      * ]}
-     * }</pre>
+     * </code></pre>
      *
      * @param  id
      *         The id of the bot.
@@ -566,6 +668,8 @@ public class RequestHandler {
      *         When the request couldn't be performed properly.
      * @throws RatelimitedException
      *         When the API gets ratelimited.
+     *
+     * @since v1.1.0
      */
     public JSONArray getBotlist(@NotNull String id, @NotNull String site) throws IOException, RatelimitedException{
         return getAll(id).getJSONObject("list_data").getJSONArray(site);
@@ -575,9 +679,10 @@ public class RequestHandler {
      * Gets the basic information of a bot including id, name, discriminator, {@link #getOwners(ShardManager) owners},
      * server_count and OAuth-link but also all sites and corresponding informations of those.
      * <br>With exception of id and the sites are the other informations based on the most common response.
+     * <br>This method directly calls {@link #getAll(String) getAll(String)}.
      *
      * <p>A response could look like this:
-     * <br><pre>{@code
+     * <br><pre><code>
      * {
      *     "id": "123456789012345678",
      *     "usernam": "MyBot",
@@ -586,19 +691,137 @@ public class RequestHandler {
      *         "234567890123456789"
      *     ],
      *     "server_count": 100,
-     *     "invite": "https://discordapp.com/oauth2/authorize?client_id=123456789012345678&scope=bot",
+     *     "invite":{@literal "https://discordapp.com/oauth2/authorize?client_id=123456789012345678&scope=bot"},
      *     "list_data": {
      *         "somebotlist.com": [
-     *             <list data>,
+     *            {@literal <list data>},
      *             200
      *         ],
      *         "otherlist.org": [
-     *             <list data>,
+     *            {@literal <list data>},
      *             404
      *         ]
      *     }
      * }
-     * }</pre>
+     * </code></pre>
+     *
+     * @param  shardManager
+     *         The instance of {@link net.dv8tion.jda.api.sharding.ShardManager ShardManager} to use.
+     *
+     * @return The Bot information as JSONObject.
+     *
+     * @throws IOException
+     *         When the request couldn't be performed properly.
+     * @throws RatelimitedException
+     *         When the API gets ratelimited.
+     *
+     * @since v1.1.0
+     *
+     * @see #getOwners(ShardManager) getOwners(ShardManager)
+     * @see #getOwners(JDA) getOwners(JDA)
+     * @see #getOwners(Long) getOwners(Long)
+     * @see #getOwners(String) getOwners(String)
+     * @see #getBotlists(ShardManager) getBotlists(ShardManager)
+     * @see #getBotlists(JDA) getBotlists(JDA)
+     * @see #getBotlists(Long) getBotlists(Long)
+     * @see #getBotlists(String) getBotlists(String)
+     * @see #getBotlist(ShardManager, String) getBotlist(ShardManager, String)
+     * @see #getBotlist(JDA, String) getBotlist(JDA, String)
+     * @see #getBotlist(Long, String) getBotlist(Long, String)
+     * @see #getBotlist(String, String) getBotlist(String, String)
+     */
+    public JSONObject getAll(@NotNull ShardManager shardManager) throws IOException, RatelimitedException{
+        return getAll(shardManager.getShardById(0).getSelfUser().getId());
+    }
+
+    /**
+     * Gets the basic information of a bot including id, name, discriminator, {@link #getOwners(JDA) owners},
+     * server_count and OAuth-link but also all sites and corresponding informations of those.
+     * <br>With exception of id and the sites are the other informations based on the most common response.
+     * <br>This method directly calls {@link #getAll(String) getAll(String)}.
+     *
+     * <p>A response could look like this:
+     * <br><pre><code>
+     * {
+     *     "id": "123456789012345678",
+     *     "usernam": "MyBot",
+     *     "discriminator": "1234",
+     *     "owners": [
+     *         "234567890123456789"
+     *     ],
+     *     "server_count": 100,
+     *     "invite":{@literal "https://discordapp.com/oauth2/authorize?client_id=123456789012345678&scope=bot"},
+     *     "list_data": {
+     *         "somebotlist.com": [
+     *            {@literal <list data>},
+     *             200
+     *         ],
+     *         "otherlist.org": [
+     *            {@literal <list data>},
+     *             404
+     *         ]
+     *     }
+     * }
+     * </code></pre>
+     *
+     * @param  jda
+     *         The instance of {@link net.dv8tion.jda.api.JDA JDA} to use.
+     *
+     * @return The Bot information as JSONObject.
+     *
+     * @throws IOException
+     *         When the request couldn't be performed properly.
+     * @throws RatelimitedException
+     *         When the API gets ratelimited.
+     *
+     * @since v1.1.0
+     *
+     * @see #getOwners(ShardManager) getOwners(ShardManager)
+     * @see #getOwners(JDA) getOwners(JDA)
+     * @see #getOwners(Long) getOwners(Long)
+     * @see #getOwners(String) getOwners(String)
+     * @see #getBotlists(ShardManager) getBotlists(ShardManager)
+     * @see #getBotlists(JDA) getBotlists(JDA)
+     * @see #getBotlists(Long) getBotlists(Long)
+     * @see #getBotlists(String) getBotlists(String)
+     * @see #getBotlist(ShardManager, String) getBotlist(ShardManager, String)
+     * @see #getBotlist(JDA, String) getBotlist(JDA, String)
+     * @see #getBotlist(Long, String) getBotlist(Long, String)
+     * @see #getBotlist(String, String) getBotlist(String, String)
+     */
+    public JSONObject getAll(@NotNull JDA jda) throws IOException, RatelimitedException{
+        return getAll(jda.getSelfUser().getId());
+    }
+
+    /**
+     * Gets the basic information of a bot including id, name, discriminator, {@link #getOwners(Long) owners},
+     * server_count and OAuth-link but also all sites and corresponding informations of those.
+     * <br>With exception of id and the sites are the other informations based on the most common response.
+     * <br>This method directly calls {@link #getAll(String) getAll(String)}.
+     *
+     * <p>A response could look like this:
+     * <br><pre><code>
+     * {
+     *     "id": "123456789012345678",
+     *     "usernam": "MyBot",
+     *     "discriminator": "1234",
+     *     "owners": [
+     *         "234567890123456789"
+     *     ],
+     *     "server_count": 100,
+     *     "invite":{@literal "https://discordapp.com/oauth2/authorize?client_id=123456789012345678&scope=bot"},
+     *     "list_data": {
+     *         "somebotlist.com": [
+     *            {@literal <list data>},
+     *             200
+     *         ],
+     *         "otherlist.org": [
+     *            {@literal <list data>},
+     *             404
+     *         ]
+     *     }
+     * }
+     * </code></pre>
      *
      * @param  id
      *         The id of the bot.
@@ -610,14 +833,77 @@ public class RequestHandler {
      * @throws RatelimitedException
      *         When the API gets ratelimited.
      *
+     * @since v1.1.0
+     *
      * @see #getOwners(ShardManager) getOwners(ShardManager)
      * @see #getOwners(JDA) getOwners(JDA)
+     * @see #getOwners(Long) getOwners(Long)
      * @see #getOwners(String) getOwners(String)
      * @see #getBotlists(ShardManager) getBotlists(ShardManager)
      * @see #getBotlists(JDA) getBotlists(JDA)
+     * @see #getBotlists(Long) getBotlists(Long)
      * @see #getBotlists(String) getBotlists(String)
      * @see #getBotlist(ShardManager, String) getBotlist(ShardManager, String)
      * @see #getBotlist(JDA, String) getBotlist(JDA, String)
+     * @see #getBotlist(Long, String) getBotlist(Long, String)
+     * @see #getBotlist(String, String) getBotlist(String, String)
+     */
+    public JSONObject getAll(Long id) throws IOException, RatelimitedException{
+        return getAll(Long.toString(id));
+    }
+
+    /**
+     * Gets the basic information of a bot including id, name, discriminator, {@link #getOwners(String) owners},
+     * server_count and OAuth-link but also all sites and corresponding informations of those.
+     * <br>With exception of id and the sites are the other informations based on the most common response.
+     *
+     * <p>A response could look like this:
+     * <br><pre><code>
+     * {
+     *     "id": "123456789012345678",
+     *     "usernam": "MyBot",
+     *     "discriminator": "1234",
+     *     "owners": [
+     *         "234567890123456789"
+     *     ],
+     *     "server_count": 100,
+     *     "invite":{@literal "https://discordapp.com/oauth2/authorize?client_id=123456789012345678&scope=bot"},
+     *     "list_data": {
+     *         "somebotlist.com": [
+     *            {@literal <list data>},
+     *             200
+     *         ],
+     *         "otherlist.org": [
+     *            {@literal <list data>},
+     *             404
+     *         ]
+     *     }
+     * }
+     * </code></pre>
+     *
+     * @param  id
+     *         The id of the bot.
+     *
+     * @return The Bot information as JSONObject.
+     *
+     * @throws IOException
+     *         When the request couldn't be performed properly.
+     * @throws RatelimitedException
+     *         When the API gets ratelimited.
+     *
+     * @since v1.1.0
+     *
+     * @see #getOwners(ShardManager) getOwners(ShardManager)
+     * @see #getOwners(JDA) getOwners(JDA)
+     * @see #getOwners(Long) getOwners(Long)
+     * @see #getOwners(String) getOwners(String)
+     * @see #getBotlists(ShardManager) getBotlists(ShardManager)
+     * @see #getBotlists(JDA) getBotlists(JDA)
+     * @see #getBotlists(Long) getBotlists(Long)
+     * @see #getBotlists(String) getBotlists(String)
+     * @see #getBotlist(ShardManager, String) getBotlist(ShardManager, String)
+     * @see #getBotlist(JDA, String) getBotlist(JDA, String)
+     * @see #getBotlist(Long, String) getBotlist(Long, String)
      * @see #getBotlist(String, String) getBotlist(String, String)
      */
     public JSONObject getAll(@NotNull String id) throws IOException, RatelimitedException{

--- a/src/main/java/com/andre601/javabotblockapi/RequestHandler.java
+++ b/src/main/java/com/andre601/javabotblockapi/RequestHandler.java
@@ -405,7 +405,7 @@ public class RequestHandler {
 
         List<String> owners = new ArrayList<>();
         for(int i = 0; i < array.length(); i++)
-            owners.add(array.getString(0));
+            owners.add(array.getString(i));
 
         return owners;
     }

--- a/src/main/java/com/andre601/javabotblockapi/RequestHandler.java
+++ b/src/main/java/com/andre601/javabotblockapi/RequestHandler.java
@@ -44,6 +44,8 @@ public class RequestHandler {
     private ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
     private final OkHttpClient CLIENT = new OkHttpClient();
 
+    private String baseUrl = "https://botblock.org/api/";
+
     private String id = null;
 
     private JSONObject json = new JSONObject();
@@ -67,8 +69,6 @@ public class RequestHandler {
      *         When the Bot (IP or ID) got ratelimited.
      * @throws NullPointerException
      *         When the ShardManager gives an invalid shard (Shard id 0 is null).
-     *
-     * @see #postGuilds(JDA, BotBlockAPI) postGuilds(JDA, BotBlockAPI) for posting with JDA.
      */
     public void postGuilds(@NotNull ShardManager shardManager, @NotNull BotBlockAPI botBlockAPI) throws IOException, RatelimitedException{
         this.id = Objects.requireNonNull(shardManager.getShardById(0), "The provided ShardManager had an invalid Shard ID.").getSelfUser().getId();
@@ -104,8 +104,6 @@ public class RequestHandler {
      *         When the post request couldn't be performed properly.
      * @throws RatelimitedException
      *         When the Bot (IP or ID) got ratelimited.
-     *
-     * @see #postGuilds(ShardManager, BotBlockAPI) postGuilds(ShardManager, BotBlockAPI) for posting with ShardManager.
      */
     public void postGuilds(@NotNull JDA jda, @NotNull BotBlockAPI botBlockAPI) throws IOException, RatelimitedException{
         this.id = jda.getSelfUser().getId();
@@ -137,10 +135,6 @@ public class RequestHandler {
      *         When the post request couldn't be performed properly.
      * @throws RatelimitedException
      *         When the Bot (IP or ID) got ratelimited.
-     *
-     * @see #postGuilds(String, int, BotBlockAPI) postGuilds(String, int, BotBlockAPI) for the full method.
-     * @see #postGuilds(ShardManager, BotBlockAPI) postGuilds(ShardManager, BotBlockAPI) for posting with ShardManager.
-     * @see #postGuilds(JDA, BotBlockAPI) postGuilds(JDA, BotBlockAPI) for posting with JDA.
      */
     public void postGuilds(Long botId, int guilds, @NotNull BotBlockAPI botBlockAPI) throws IOException, RatelimitedException{
         postGuilds(Long.toString(botId), guilds, botBlockAPI);
@@ -160,9 +154,6 @@ public class RequestHandler {
      *         When the post request couldn't be performed properly.
      * @throws RatelimitedException
      *         When the Bot (IP or ID) got ratelimited.
-     *
-     * @see #postGuilds(ShardManager, BotBlockAPI) postGuilds(ShardManager, BotBlockAPI) for posting with ShardManager.
-     * @see #postGuilds(JDA, BotBlockAPI) postGuilds(JDA, BotBlockAPI) for posting with JDA.
      */
     public void postGuilds(@NotNull String botId, int guilds, @NotNull BotBlockAPI botBlockAPI) throws IOException, RatelimitedException{
         if(ObjectUtils.isEmpty(botId))
@@ -186,8 +177,6 @@ public class RequestHandler {
      *         The {@link net.dv8tion.jda.api.sharding.ShardManager ShardManager instance} that should be used.
      * @param  botBlockAPI
      *         The {@link com.andre601.javabotblockapi.BotBlockAPI BotBlockAPI instance} that should be used.
-     *
-     * @see #startAutoPosting(JDA, BotBlockAPI) startAutoPosting(JDA, BotBlockAPI) for posting with JDA.
      */
     public void startAutoPosting(@NotNull ShardManager shardManager, @NotNull BotBlockAPI botBlockAPI){
         scheduler.scheduleAtFixedRate(() -> {
@@ -207,8 +196,6 @@ public class RequestHandler {
      *         The {@link net.dv8tion.jda.api.JDA JDA instance} that should be used.
      * @param  botBlockAPI
      *         The {@link com.andre601.javabotblockapi.BotBlockAPI BotBlockAPI instance} that should be used.
-     *
-     * @see #startAutoPosting(ShardManager, BotBlockAPI) startAutoPosting(ShardManager, BotBlockAPI) for posting with ShardManager.
      */
     public void startAutoPosting(@NotNull JDA jda, @NotNull BotBlockAPI botBlockAPI){
         scheduler.scheduleAtFixedRate(() -> {
@@ -229,9 +216,6 @@ public class RequestHandler {
      *         The guilds the bot is in.
      * @param  botBlockAPI
      *         The {@link com.andre601.javabotblockapi.BotBlockAPI BotBlockAPI instance} that should be used.
-     *
-     * @see #startAutoPosting(JDA, BotBlockAPI) startAutoPosting(JDA, BotBlockAPI) for posting with JDA.
-     * @see #startAutoPosting(ShardManager, BotBlockAPI) startAutoPosting(ShardManager, BotBlockAPI) for posting with ShardManager.
      */
     public void startAutoPosting(Long botId, int guilds, @NotNull BotBlockAPI botBlockAPI){
         scheduler.scheduleAtFixedRate(() -> {
@@ -252,9 +236,6 @@ public class RequestHandler {
      *         The guilds the bot is in.
      * @param  botBlockAPI
      *         The {@link com.andre601.javabotblockapi.BotBlockAPI BotBlockAPI instance} that should be used.
-     *
-     * @see #startAutoPosting(JDA, BotBlockAPI) startAutoPosting(JDA, BotBlockAPI) for posting with JDA.
-     * @see #startAutoPosting(ShardManager, BotBlockAPI) startAutoPosting(ShardManager, BotBlockAPI) for posting with ShardManager.
      */
     public void startAutoPosting(@NotNull String botId, int guilds, @NotNull BotBlockAPI botBlockAPI){
         scheduler.scheduleAtFixedRate(() -> {
@@ -280,9 +261,11 @@ public class RequestHandler {
         if(ObjectUtils.isEmpty(id))
             throw new NullPointerException("botId may not be empty!");
 
+        String url = baseUrl + "count";
+
         RequestBody body = RequestBody.create(null, json.toString());
         Request request = new Request.Builder()
-                .url("https://botblock.org/api/count")
+                .url(url)
                 .addHeader("User-Agent", id)
                 .addHeader("Content-Type", "application/json") // Some sites require this in the header.
                 .post(body)
@@ -330,6 +313,339 @@ public class RequestHandler {
                         String.join(", ", sites)
                 ));
             }
+        }
+    }
+
+    /**
+     * Gets the owners of a bot as a list.
+     * <br>This method calls {@link com.andre601.javabotblockapi.RequestHandler#getAll(String) getOwners(String)}.
+     *
+     * @param  shardManager
+     *         The {@link net.dv8tion.jda.api.sharding.ShardManager ShardManager instance} that should be used.
+     *
+     * @return The owners as a list.
+     *
+     * @throws IOException
+     *         When the request couldn't be performed properly.
+     * @throws RatelimitedException
+     *         When the API gets ratelimited.
+     *
+     * @see #getOwners(String) getOwners(String)
+     */
+    public List<String> getOwners(@NotNull ShardManager shardManager) throws IOException, RatelimitedException{
+        return getOwners(shardManager.getShardById(0).getSelfUser().getId());
+    }
+
+
+    /**
+     * Gets the owners of a bot as a list.
+     * <br>This method calls {@link com.andre601.javabotblockapi.RequestHandler#getAll(String) getOwners(String)}.
+     *
+     * @param  jda
+     *         The {@link net.dv8tion.jda.api.JDA JDA instance} that should be used.
+     *
+     * @return The owners as a list.
+     *
+     * @throws IOException
+     *         When the request couldn't be performed properly.
+     * @throws RatelimitedException
+     *         When the API gets ratelimited.
+     *
+     * @see #getOwners(String) getOwners(String)
+     */
+    public List<String> getOwners(@NotNull JDA jda) throws IOException, RatelimitedException{
+        return getOwners(jda.getSelfUser().getId());
+    }
+
+    /**
+     * Gets the owners of a bot as a List.
+     *
+     * @param  id
+     *         The ID of the bot to get information from.
+     *
+     * @return The owners as a list.
+     *
+     * @throws IOException
+     *         When the post request couldn't be performed properly.
+     * @throws RatelimitedException
+     *         When the Bot (IP or ID) got ratelimited.
+     */
+    public List<String> getOwners(@NotNull String id) throws IOException, RatelimitedException{
+        JSONObject json = getAll(id);
+
+        JSONArray array = json.getJSONArray("owners");
+
+        List<String> owners = new ArrayList<>();
+        for(int i = 0; i < array.length(); i++)
+            owners.add(array.getString(0));
+
+        return owners;
+    }
+
+    /**
+     * Gets all the available Botlists as JSONObject.
+     * <br>This method calls {@link com.andre601.javabotblockapi.RequestHandler#getBotlists(String) getBotlists(String)}.
+     *
+     * <p>The JSONObject will look something like this:
+     * <br><pre>{@code
+     * {
+     *   "somebotlist.com": [
+     *     <botlist data>,
+     *     200
+     *   ],
+     *   "otherlist.org": [
+     *     <botlist data>,
+     *     404
+     *   ]
+     * }
+     * }</pre>
+     *
+     * @param  shardManager
+     *         The {@link net.dv8tion.jda.api.sharding.ShardManager ShardManager instance} that should be used.
+     *
+     * @return The Botlists as JSONObject.
+     *
+     * @throws IOException
+     *         When the request couldn't be performed properly.
+     * @throws RatelimitedException
+     *         When the API gets ratelimited.
+     *
+     * @see #getBotlists(String) getBotlists(String)
+     */
+    public JSONObject getBotlists(@NotNull ShardManager shardManager) throws IOException, RatelimitedException{
+        return getBotlists(shardManager.getShardById(0).getSelfUser().getId());
+    }
+
+
+    /**
+     * Gets all the available Botlists as JSONObject.
+     * <br>This method calls {@link com.andre601.javabotblockapi.RequestHandler#getBotlists(String) getBotlists(String)}.
+     *
+     * <p>The JSONObject will look something like this:
+     * <br><pre>{@code
+     * {
+     *   "somebotlist.com": [
+     *     <botlist data>,
+     *     200
+     *   ],
+     *   "otherlist.org": [
+     *     <botlist data>,
+     *     404
+     *   ]
+     * }
+     * }</pre>
+     *
+     * @param  jda
+     *         The {@link net.dv8tion.jda.api.JDA jda instance} that should be used.
+     *
+     * @return The Botlists as JSONObject.
+     *
+     * @throws IOException
+     *         When the request couldn't be performed properly.
+     * @throws RatelimitedException
+     *         When the API gets ratelimited.
+     *
+     * @see #getBotlists(String) getBotlists(String)
+     */
+    public JSONObject getBotlists(@NotNull JDA jda) throws IOException, RatelimitedException{
+        return getBotlists(jda.getSelfUser().getId());
+    }
+
+
+    /**
+     * Gets all the available Botlists as JSONObject.
+     *
+     * <p>The JSONObject will look something like this:
+     * <br><pre>{@code
+     * {
+     *   "somebotlist.com": [
+     *     <botlist data>,
+     *     200
+     *   ],
+     *   "otherlist.org": [
+     *     <botlist data>,
+     *     404
+     *   ]
+     * }
+     * }</pre>
+     *
+     * @param  id
+     *         The id of the bot
+     *
+     * @return The Botlists as JSONObject.
+     *
+     * @throws IOException
+     *         When the request couldn't be performed properly.
+     * @throws RatelimitedException
+     *         When the API gets ratelimited.
+     */
+    public JSONObject getBotlists(@NotNull String id) throws IOException, RatelimitedException{
+        return getAll(id).getJSONObject("list_data");
+    }
+
+    /**
+     * Gets a specific botlist-information as JSONArray.
+     *
+     * <p>The JSONObject will look something like this:
+     * <br><pre>{@code
+     * {[
+     *   <botlist data>,
+     *   200
+     * ]}
+     * }</pre>
+     *
+     * @param  shardManager
+     *         The {@link net.dv8tion.jda.api.sharding.ShardManager ShardManager instance} that should be used.
+     * @param  site
+     *         The sites name to get information from.
+     *         <br>A list of supported sites can be found <a href="https://botblock.org/api/docs#count" target="_blank">here</a>.
+     *
+     * @return The sites information as JSONArray.
+     *
+     * @throws IOException
+     *         When the request couldn't be performed properly.
+     * @throws RatelimitedException
+     *         When the API gets ratelimited.
+     *
+     * @see #getBotlist(String, String) getBotlist(String, String)
+     */
+    public JSONArray getBotlist(@NotNull ShardManager shardManager, @NotNull String site) throws IOException, RatelimitedException{
+        return getBotlist(shardManager.getShardById(0).getSelfUser().getId(), site);
+    }
+
+    /**
+     * Gets a specific botlist-information as JSONArray.
+     *
+     * <p>The JSONObject will look something like this:
+     * <br><pre>{@code
+     * {[
+     *   <botlist data>,
+     *   200
+     * ]}
+     * }</pre>
+     *
+     * @param  jda
+     *         The {@link net.dv8tion.jda.api.JDA JDA instance} that should be used.
+     * @param  site
+     *         The sites name to get information from.
+     *         <br>A list of supported sites can be found <a href="https://botblock.org/api/docs#count" target="_blank">here</a>.
+     *
+     * @return The sites information as JSONArray.
+     *
+     * @throws IOException
+     *         When the request couldn't be performed properly.
+     * @throws RatelimitedException
+     *         When the API gets ratelimited.
+     *
+     * @see #getBotlist(String, String) getBotlist(String, String)
+     */
+    public JSONArray getBotlist(@NotNull JDA jda, String site) throws IOException, RatelimitedException{
+        return getBotlist(jda.getSelfUser().getId(), site);
+    }
+
+    /**
+     * Gets a specific botlist-information as JSONArray.
+     *
+     * <p>The JSONObject will look something like this:
+     * <br><pre>{@code
+     * {[
+     *   <botlist data>,
+     *   200
+     * ]}
+     * }</pre>
+     *
+     * @param  id
+     *         The id of the bot.
+     * @param  site
+     *         The sites name to get information from.
+     *         <br>A list of supported sites can be found <a href="https://botblock.org/api/docs#count" target="_blank">here</a>.
+     *
+     * @return The sites information as JSONArray.
+     *
+     * @throws IOException
+     *         When the request couldn't be performed properly.
+     * @throws RatelimitedException
+     *         When the API gets ratelimited.
+     */
+    public JSONArray getBotlist(@NotNull String id, @NotNull String site) throws IOException, RatelimitedException{
+        return getAll(id).getJSONObject("list_data").getJSONArray(site);
+    }
+
+    /**
+     * Gets the basic information of a bot including id, name, discriminator, {@link #getOwners(ShardManager) owners},
+     * server_count and OAuth-link but also all sites and corresponding informations of those.
+     * <br>With exception of id and the sites are the other informations based on the most common response.
+     *
+     * <p>A response could look like this:
+     * <br><pre>{@code
+     * {
+     *     "id": "123456789012345678",
+     *     "usernam": "MyBot",
+     *     "discriminator": "1234",
+     *     "owners": [
+     *         "234567890123456789"
+     *     ],
+     *     "server_count": 100,
+     *     "invite": "https://discordapp.com/oauth2/authorize?client_id=123456789012345678&scope=bot",
+     *     "list_data": {
+     *         "somebotlist.com": [
+     *             <list data>,
+     *             200
+     *         ],
+     *         "otherlist.org": [
+     *             <list data>,
+     *             404
+     *         ]
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param  id
+     *         The id of the bot.
+     *
+     * @return The Bot information as JSONObject.
+     *
+     * @throws IOException
+     *         When the request couldn't be performed properly.
+     * @throws RatelimitedException
+     *         When the API gets ratelimited.
+     *
+     * @see #getOwners(ShardManager) getOwners(ShardManager)
+     * @see #getOwners(JDA) getOwners(JDA)
+     * @see #getOwners(String) getOwners(String)
+     * @see #getBotlists(ShardManager) getBotlists(ShardManager)
+     * @see #getBotlists(JDA) getBotlists(JDA)
+     * @see #getBotlists(String) getBotlists(String)
+     * @see #getBotlist(ShardManager, String) getBotlist(ShardManager, String)
+     * @see #getBotlist(JDA, String) getBotlist(JDA, String)
+     * @see #getBotlist(String, String) getBotlist(String, String)
+     */
+    public JSONObject getAll(@NotNull String id) throws IOException, RatelimitedException{
+        String url = baseUrl + "bots/" + id;
+
+        Request request = new Request.Builder()
+                .url(url)
+                .addHeader("User-Agent", id)
+                .build();
+
+        try(Response response = CLIENT.newCall(request).execute()){
+            Objects.requireNonNull(response.body(), "Received empty body from BotBlocks API.");
+
+            if(response.body().string().isEmpty())
+                throw new NullPointerException("Received empty body from BotBlocks API.");
+
+            if(!response.isSuccessful()){
+                if(response.code() == 429)
+                    throw new RatelimitedException(response.body().string());
+
+                throw new IOException(String.format(
+                        "Couldn't get Bot information. Site responded with %d (%s)",
+                        response.code(),
+                        response.message()
+                ));
+            }
+
+            return new JSONObject(response.body().string());
         }
     }
 }


### PR DESCRIPTION
This commit will make JavaBotBlockAPI support the latest [JDA version](https://github.com/DV8FromTheWorld/JDA) (`4.BETA.0_11` as of now).
This version of the API **won't** be backwards compatible due to changes in the JDA path meaning that if you want to use this API in JDA 4 you have to use this version here and if you want to use it with JDA 3 you have to go with [v1.0.5](https://github.com/Andre601/JavaBotBlockAPI/releases/tag/v1.0.5)